### PR TITLE
added docker configs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM php:7.0.27-apache
+
+# Dependencies and maybe some debugging
+RUN apt-get update && apt-get install -y curl git vim && rm -rf /var/lib/apt/lists/*
+
+# Set up PHP and apache
+RUN ln -s /etc/apache2/mods-available/rewrite.load /etc/apache2/mods-enabled/rewrite.load
+RUN touch /usr/local/etc/php/php.ini
+RUN sed -i 's|/var/www/html|/var/www/html/public|g' /etc/apache2/sites-available/000-default.conf
+RUN docker-php-ext-install pdo pdo_mysql
+
+# Install Composer
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
+    && php composer-setup.php --install-dir=/usr/local/bin --filename=composer \
+    && php -r "unlink('composer-setup.php');"
+
+# Copy project to folder
+RUN chmod 777 /var/www
+ADD . /var/www/html
+WORKDIR /var/www/html
+
+# Run composer
+USER www-data
+RUN composer install
+USER root
+
+# Set owner for PHP
+RUN chown -R www-data:www-data /var/www/html
+
+# Connect to MySQL
+RUN sed -i "s|host: 'localhost'|host: 'tdt4237public_mysql_1'|g" /var/www/html/App/config.yml
+RUN sed -i "s|password: ''|password: 'barePassord'|g" /var/www/html/App/config.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+# Docker-compose config
+#
+# To build services run:
+# $> docker-compose rebuilding
+# To start services:
+# $> docker-compose up
+# To stop services:
+# $> docker-compose down
+# To import MySQL
+# $> cat sql.txt | mysql -uroot -pbarePassord --host=0.0.0.0 --port=3306
+# Access Bash inside the container
+# $> docker exec -ti tdt4237public_webapp_1 bash
+
+version: '3'
+services:
+  webapp:
+    build: .
+    image: tdt4237-public
+    expose:
+      - "80"
+      - "443"
+    ports:
+      - "80:80"
+      - "443:443"
+    working_dir: /var/www/html
+    depends_on:
+      - mysql
+    networks:
+      - tdt4237
+  mysql:
+    image: mysql:5.7
+    environment:
+      MYSQL_ROOT_PASSWORD: 'barePassord'
+    expose:
+      - "3306"
+    ports:
+      - "3306:3306"
+    networks:
+      - tdt4237
+networks:
+  tdt4237:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # Docker-compose config
 #
 # To build services run:
-# $> docker-compose rebuilding
+# $> docker-compose build
 # To start services:
 # $> docker-compose up
 # To stop services:

--- a/sql.txt
+++ b/sql.txt
@@ -1,6 +1,9 @@
 ﻿SET SQL_MODE = "NO_AUTO_VALUE_ON_ZERO";
 SET time_zone = "+00:00";
 
+CREATE DATABASE IF NOT EXISTS inventory;
+
+USE inventory;
 
 CREATE TABLE IF NOT EXISTS `categories` (
   `id` int(11) NOT NULL,
@@ -98,7 +101,7 @@ CREATE TABLE IF NOT EXISTS `users` (
   `id` int(11) NOT NULL,
   `username` varchar(255) NOT NULL,
   `password` varchar(255) NOT NULL,
-  `email` varchar(255) NOT NULL,
+  `email` varchar(255),
   `created_at` varchar(255) NOT NULL,
   `admin` boolean NOT NULL
 ) ENGINE=MyISAM AUTO_INCREMENT=4 DEFAULT CHARSET=utf8;


### PR DESCRIPTION
You can use these docker configs to help others run it on linux/mac

Feel free to add commands mentioned in docker-compose.yml to Readme

It's possible to drop the changes in sql.txt that I have done, but added creation of database inventory makes import faster (like: cat sql.txt | mysql -uroot -pbarePassord --host=0.0.0.0 --port=3306), and if email is required for table users it breaks on registration (Is it by design that model is missing required field?)